### PR TITLE
Fix deprecations for Julia v0.6

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,6 @@
 using CsminWel
 using Base.Test
 
-
 f(x) = sum(x.^2)
 function grad(x)
     2*x, false
@@ -21,7 +20,7 @@ res3 = CsminWel.csminwel(f, [0.1,0.1], H = eye(2))
 
 res4 = optimize(f, g!, [.1, .1], Csminwel())
 res5 = optimize(f, [.1, .1], Csminwel())   ## Default to finite difference
-res6 = optimize(OnceDifferentiable(f, [.1, .1], autodiff = :forward), Csminwel())
+res6 = optimize(OnceDifferentiable(f, [.1, .1]; autodiff = :forward), [.1, .1], Csminwel())
 
 
 @test Optim.minimum(res0) ≈ Optim.minimum(res1) atol=1.0e-9
@@ -31,9 +30,7 @@ res6 = optimize(OnceDifferentiable(f, [.1, .1], autodiff = :forward), Csminwel()
 @test Optim.minimum(res4) ≈ Optim.minimum(res5) atol=1.0e-9
 @test Optim.minimum(res6) ≈ Optim.minimum(res6) atol=1.0e-9
 
-#=
-Maximizing loglikelihood logistic models
-=#
+#Maximizing loglikelihood logistic models
 using StatsFuns
 srand(1)
 x = [ones(200) randn(200,4)]
@@ -57,8 +54,8 @@ end
 res1 = optimize(loglik, g!, zeros(5), BFGS())
 res2 = optimize(loglik, g!, zeros(5), Csminwel())
 res3 = optimize(loglik, zeros(5), Csminwel())
-res4 = optimize(Optim.OnceDifferentiable(loglik, zeros(5), autodiff = :forward), Csminwel())
-res5 = optimize(Optim.OnceDifferentiable(loglik, zeros(5), autodiff = :finite), Csminwel())
+res4 = optimize(Optim.OnceDifferentiable(loglik, zeros(5), autodiff = :forward), zeros(5), Csminwel())
+res5 = optimize(Optim.OnceDifferentiable(loglik, zeros(5), autodiff = :finite), zeros(5), Csminwel())
 
 
 @test Optim.minimum(res1) ≈ Optim.minimum(res2) atol=1.0e-9
@@ -69,5 +66,4 @@ res5 = optimize(Optim.OnceDifferentiable(loglik, zeros(5), autodiff = :finite), 
 
 res = optimize(loglik, g!, zeros(5), Csminwel(), Optim.Options(extended_trace = true, show_trace = true, store_trace = true))
 
-
-@test isa(res.trace, Array{Optim.OptimizationState{CsminWel.Csminwel},1})
+@test isa(res.trace, Array{Optim.OptimizationState{Float64,CsminWel.Csminwel},1})


### PR DESCRIPTION
I adapted the existing code of CsminWel.jl to work with the last versions of Optim, NLSolvers Base and ForwardDiff, namely : 
Optim                         0.14.1
NLSolversBase                 4.4.1
ForwardDiff                   0.7.5
I also changed the codes for runtests.jl, which were not longer working properly with the new syntaxes of the function OnceDifferentiable present in the last version of NLSolversBase and, therefore, Optim.

The original tests are passed. In addition, I use the modified code in my own research for log-likelihood maximization for a medium-scale DSGE model and it works well.